### PR TITLE
chore(deps): bump minimist from 1.1.3 to 1.2.3 (#1)

### DIFF
--- a/github-to-newrelic/package-lock.json
+++ b/github-to-newrelic/package-lock.json
@@ -522,8 +522,8 @@
       }
     },
     "minimist": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
       "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
       "dev": true
     },


### PR DESCRIPTION
Resolves [this Dependabot alert](https://github.com/newrelic-experimental/newrelic-serverless-github-webhook/network/alert/github-to-newrelic/package-lock.json/minimist/open)